### PR TITLE
Enable timestamp to work on OSX

### DIFF
--- a/fish/functions/timestamp.fish
+++ b/fish/functions/timestamp.fish
@@ -1,10 +1,17 @@
+# spit out current time stamp, or decode one if passed in
 function timestamp
+    set datecmd date
+    if [ (uname) = "Darwin" ]
+        set datecmd gdate
+    end
+
     if test (count $argv) -gt 0
         for ts in $argv
             set ts (echo $ts | cut -c 1-10)
-            date -d @$ts
+            $datecmd -d @$ts # decode timestamp
         end
     else
-        date +%s
+        # print timestamp
+        $datecmd +%s
     end
 end


### PR DESCRIPTION
OSX ships with BSD utils be default. If the user has installed `coreutils` with brew, this script will pick up `gdate` instead.

Tested: Locally on OSX machine. NOT tested on linux.